### PR TITLE
Fixed AmazonS3->files() implementation

### DIFF
--- a/src/Dmyers/Storage/Adapter/AmazonS3.php
+++ b/src/Dmyers/Storage/Adapter/AmazonS3.php
@@ -216,10 +216,18 @@ class AmazonS3 extends Base
 	 */
 	public function files($path)
 	{
-		return $this->client->listKeys(array(
+		$files = array();
+		
+		$iterator = $this->client->getIterator('ListObjects', array(
 			'Bucket' => $this->bucket,
 			'Prefix' => $this->computePath($path),
 		));
+		
+		foreach ($iterator as $object) {
+			$files[] = $object['Key'];
+		}
+		
+		return $files;
 	}
 	
 	/**


### PR DESCRIPTION
I'm not sure if it ever worked before, but currently the implementation is broken: there's no `listKeys()` method on `S3Client` class.

This PR fixes the implementation to use the high-level `getIterator('ListObjects')` iterator, as documented on AWS SDK for PHP [here](http://docs.aws.amazon.com/AmazonS3/latest/dev/ListingObjectKeysUsingPHP.html) and [here](http://docs.aws.amazon.com/aws-sdk-php/latest/class-Aws.S3.S3Client.html#_listObjects).
