### PR TITLE
Added support for configuring AWS S3 CNAME.

### DIFF
--- a/src/Dmyers/Storage/Adapter/AmazonS3.php
+++ b/src/Dmyers/Storage/Adapter/AmazonS3.php
@@ -235,7 +235,17 @@ class AmazonS3 extends Base
 	 */
 	public function url($path)
 	{
-		return $this->client->getObjectUrl($this->bucket, $this->computePath($path));
+		$url = $this->client->getObjectUrl($this->bucket, $this->computePath($path));
+
+		if ($cname = $this->config('cname')) {
+			return str_replace(
+				parse_url($url, PHP_URL_HOST),
+				$cname,
+				str_replace("{$this->config('bucket')}/", '', $url)
+			);
+		}
+
+		return $url;
 	}
 	
 	protected function ensureBucketExists()

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -27,6 +27,7 @@ return array(
 		'secret' => '',
 		'region' => 'us-east-1',
 		'bucket' => '',
+		'cname'  => '',
 		'acl'    => 'public-read',
 	),
 	


### PR DESCRIPTION
So I have came up with another feature request! :)

This enables us to use a custom previously-configured CNAME ([Amazon CloudFront CDN](http://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/MigrateS3ToCloudFront.html)) to be used when building URLs, thus serving the files with a custom domain.

Hope you like it! :+1: 
